### PR TITLE
[GUI-128] Add entry Mongoose node dynamically. 

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,6 +25,8 @@ Provides web interface for Mongoose - storage performance testing tool maintaine
 4. [Deploying](#4-deploying)
 5. [Troubleshooting](#5-troubleshooting)<br/>
 &nbsp;&nbsp;5.1 [Running Mongoose on localhost (Mac, Windows)](#51-running-mongoose-on-localhost-mac-windows)<br/>
+5. [Open issues](#6-open-issues)<br/>
+&nbsp;&nbsp;6.1 [Mongoose run logs unavailability](#61-mongoose-run-logs-unavailability)
 
 
 # 1. Overview 
@@ -177,3 +179,17 @@ Mongoose image is being loaded into the [docker hub](https://hub.docker.com/r/em
 ## 5.1 Running Mongoose on localhost (Mac, Windows)
 
 See [Using Mongoose Web UI on Mac or Windows](console/supporting-files/windows-and-mac-support).
+
+# 6. Open issues 
+We're constantly working on making the UI and Mongoose project overall better. 
+In this section, you'd find a list of a high-priority issues that would be fixed as soon as possible.
+
+## 6.1 Mongoose run logs unavailability 
+Mongoose run's table is constructed based on the retrieved data from Prometheus: run ID, additional nodes, load step ID, etc. The list doesn't contain entry node address. <br/>
+<b>Now</b>: Mongoose run's entry nodes addresses are stored within browser's local storage. It helps to retain the information about entry nodes as long as the local storage not getting cleaned up, yet it'd be saved even if the browser and/or tab has been closed.<br/>
+We need entry node's address in order to get logs via POST request with Mongoose Logs API to its entry node. 
+<b>Problem</b>: while working outside of the browser from which Mongoose run has been launched (other browser, other computer, etc.), the data about run's entry node is missing, thus logs couldn't be gathered via the Logs API.<br/>
+
+Track progress on the issue [here](https://mongoose-issues.atlassian.net/projects/GUI/issues/GUI-137?filter=allissues).
+
+

--- a/README.md
+++ b/README.md
@@ -187,7 +187,7 @@ In this section, you'd find a list of a high-priority issues that would be fixed
 ## 6.1 Mongoose run logs unavailability 
 Mongoose run's table is constructed based on the retrieved data from Prometheus: run ID, additional nodes, load step ID, etc. The list doesn't contain entry node address. <br/>
 <b>Now</b>: Mongoose run's entry nodes addresses are stored within browser's local storage. It helps to retain the information about entry nodes as long as the local storage not getting cleaned up, yet it'd be saved even if the browser and/or tab has been closed.<br/>
-We need entry node's address in order to get logs via POST request with Mongoose Logs API to its entry node. 
+We need entry node's address in order to get logs via POST request with Mongoose Logs API to its entry node. <br/>
 <b>Problem</b>: while working outside of the browser from which Mongoose run has been launched (other browser, other computer, etc.), the data about run's entry node is missing, thus logs couldn't be gathered via the Logs API.<br/>
 
 Track progress on the issue [here](https://mongoose-issues.atlassian.net/projects/GUI/issues/GUI-137?filter=allissues).

--- a/console/package-lock.json
+++ b/console/package-lock.json
@@ -6893,6 +6893,14 @@
       "resolved": "https://registry.npmjs.org/ngx-json-viewer/-/ngx-json-viewer-2.4.0.tgz",
       "integrity": "sha512-26QmLp+0ds90aFug3KbSIwqtmQgCcJYFNNNcmcZHgPRj75nhKzbo4ceKxkhWmY5auKZClVO0HTZSs5bBhgb1Bw=="
     },
+    "ngx-webstorage-service": {
+      "version": "4.0.1",
+      "resolved": "https://registry.npmjs.org/ngx-webstorage-service/-/ngx-webstorage-service-4.0.1.tgz",
+      "integrity": "sha512-hSWmwnj+hHBdwMZDeFbJjzXKUrJMw86B3l74cb6LePM97Vu8D62MTOPj2+ABB5NMIkUhxgO1E27ih/zhrEd9Fg==",
+      "requires": {
+        "tslib": "^1.9.0"
+      }
+    },
     "nice-try": {
       "version": "1.0.5",
       "resolved": "https://registry.npmjs.org/nice-try/-/nice-try-1.0.5.tgz",

--- a/console/package.json
+++ b/console/package.json
@@ -35,6 +35,7 @@
     "jsoneditor": "^5.26.3",
     "ng2-charts": "^2.2.2",
     "ngx-json-viewer": "^2.4.0",
+    "ngx-webstorage-service": "^4.0.1",
     "popper.js": "^1.14.6",
     "rxjs": "^6.2.2",
     "zone": "^0.3.4",

--- a/console/src/app/core/models/run-record.model.ts
+++ b/console/src/app/core/models/run-record.model.ts
@@ -94,6 +94,10 @@ export class MongooseRunRecord implements OnDestroy {
         this.duration = updatedDuration;
     }
 
+    public getEntryNodeAddress(): string { 
+        return this.entryNode.getEntryNodeAddress();
+    }
+
     // MARK: - Private 
 
 }

--- a/console/src/app/core/models/run-record.model.ts
+++ b/console/src/app/core/models/run-record.model.ts
@@ -1,6 +1,7 @@
 import { MongooseRunStatus } from './mongoose-run-status';
 import { BehaviorSubject, Subscription, Observable } from 'rxjs';
 import { OnDestroy } from '@angular/core';
+import { MongooseRunEntryNode } from '../services/local-storage-service/MongooseRunEntryNode';
 
 export class MongooseRunRecord implements OnDestroy {
 
@@ -10,7 +11,7 @@ export class MongooseRunRecord implements OnDestroy {
     public nodes: String[];
     public comment: String;
 
-    private readonly runId: String;
+    private readonly entryNode: MongooseRunEntryNode;
     private loadStepId: String = ""; 
 
     private duration: string;
@@ -20,8 +21,7 @@ export class MongooseRunRecord implements OnDestroy {
 
     // MARK: - Lifecycle 
 
-    constructor(runId: String, loadStepId: String, mongooseRunStatus$: Observable<MongooseRunStatus>, startTime: String, nodes: String[], duration: string, comment: String) {
-        this.runId = runId;
+    constructor(loadStepId: String, mongooseRunStatus$: Observable<MongooseRunStatus>, startTime: String, nodes: String[], duration: string, comment: String, entryNode: MongooseRunEntryNode) {
         this.loadStepId = loadStepId;
         this.startTime = startTime;
         this.nodes = nodes;
@@ -29,6 +29,7 @@ export class MongooseRunRecord implements OnDestroy {
         this.comment = comment;
 
         this.status$ = mongooseRunStatus$; 
+        this.entryNode = entryNode;
         this.statusSubscription.add(mongooseRunStatus$.subscribe(
             fetchedStatus => {
                 this.currentStatus = fetchedStatus;
@@ -62,7 +63,7 @@ export class MongooseRunRecord implements OnDestroy {
     }
 
     public getRunId(): String {
-        return this.runId;
+        return this.entryNode.getRunId();
     }
 
     public getNodesList(): String[] {

--- a/console/src/app/core/services/control-api/control-api.service.ts
+++ b/console/src/app/core/services/control-api/control-api.service.ts
@@ -29,7 +29,7 @@ export class ControlApiService {
     return this.mongooseHostIp;
   }
 
-  public runMongoose(mongooseJsonConfiguration: Object, javaScriptScenario: String = ""): Observable<any> {
+  public runMongoose(entryNodeAddress: string, mongooseJsonConfiguration: Object, javaScriptScenario: String = ""): Observable<any> {
 
     // NOTE: Using JSON.stirngly(...) to pass Scenario as a HTTP parameter. It could contains multiple quotes, JSON.stringfy(...) handles it well. 
     javaScriptScenario = JSON.stringify(javaScriptScenario);
@@ -37,7 +37,7 @@ export class ControlApiService {
     let formData = new FormData();
     formData.append('defaults', JSON.stringify(mongooseJsonConfiguration));
 
-    return this.http.post(this.mongooseHostIp + '/run?defaults=' + formData + "&scenario=" + javaScriptScenario, this.getHttpHeadersForMongooseRun(), { observe: "response" }).pipe(
+    return this.http.post(`${Constants.Http.HTTP_PREFIX}${entryNodeAddress}` + '/run?defaults=' + formData + "&scenario=" + javaScriptScenario, {headers:this.getHttpHeadersForMongooseRun()}, { observe: "response" }).pipe(
       map(runResponse => {
         let runId = runResponse.headers.get(MongooseApi.Headers.ETAG);
         return runId;

--- a/console/src/app/core/services/control-api/control-api.service.ts
+++ b/console/src/app/core/services/control-api/control-api.service.ts
@@ -34,10 +34,14 @@ export class ControlApiService {
     // NOTE: Using JSON.stirngly(...) to pass Scenario as a HTTP parameter. It could contains multiple quotes, JSON.stringfy(...) handles it well. 
     javaScriptScenario = JSON.stringify(javaScriptScenario);
 
-    let formData = new FormData();
-    formData.append('defaults', JSON.stringify(mongooseJsonConfiguration));
+    let configurationFormData = new FormData();
+    configurationFormData.append('defaults', new Blob([JSON.stringify(mongooseJsonConfiguration)], {type: "application/json"}));
 
-    return this.http.post(`${Constants.Http.HTTP_PREFIX}${entryNodeAddress}` + '/run?defaults=' + formData + "&scenario=" + javaScriptScenario, {headers:this.getHttpHeadersForMongooseRun()}, { observe: "response" }).pipe(
+    // let scenarioFormData = new FormData();
+    configurationFormData.append('scenario', new Blob([JSON.stringify(javaScriptScenario)], {type: "text/plain"}));
+
+    // let mongooseRunArguments = [configurationFormData, scenarioFormData];
+    return this.http.post(`${Constants.Http.HTTP_PREFIX}${entryNodeAddress}` + "/run", configurationFormData, { observe: "response" }).pipe(
       map(runResponse => {
         let runId = runResponse.headers.get(MongooseApi.Headers.ETAG);
         return runId;
@@ -115,7 +119,6 @@ export class ControlApiService {
 
   private getHttpHeadersForMongooseRun(): HttpHeaders {
     let httpHeadersForMongooseRun = new HttpHeaders();
-    httpHeadersForMongooseRun.append('Content-Type', 'multipart/form-data');
     httpHeadersForMongooseRun.append('Accept', '*/*');
     return httpHeadersForMongooseRun;
   }

--- a/console/src/app/core/services/control-api/control-api.service.ts
+++ b/console/src/app/core/services/control-api/control-api.service.ts
@@ -25,7 +25,7 @@ export class ControlApiService {
 
   // MARK: - Public
 
-  public getMongooseIp(): string { 
+  public getMongooseIp(): string {
     return this.mongooseHostIp;
   }
 
@@ -35,16 +35,16 @@ export class ControlApiService {
 
     let configurationFormData = new FormData();
 
-    let mongooseConfigurationBlob = new Blob([JSON.stringify(mongooseJsonConfiguration)], {type: "application/json"});
+    let mongooseConfigurationBlob = new Blob([JSON.stringify(mongooseJsonConfiguration)], { type: "application/json" });
     configurationFormData.append('defaults', mongooseConfigurationBlob);
-    
+
     const emptyValue = "";
-    if (javaScriptScenario != emptyValue) { 
+    if (javaScriptScenario != emptyValue) {
       javaScriptScenario = JSON.stringify(javaScriptScenario);
-      let mongooseRunScenarioBlob = new Blob([JSON.stringify(javaScriptScenario)], {type: "text/plain"});
+      let mongooseRunScenarioBlob = new Blob([JSON.stringify(javaScriptScenario)], { type: "text/plain" });
       configurationFormData.append('scenario', mongooseRunScenarioBlob);
     }
-   
+
 
     return this.http.post(`${Constants.Http.HTTP_PREFIX}${entryNodeAddress}` + "/run", configurationFormData, { observe: "response" }).pipe(
       map(runResponse => {
@@ -53,21 +53,21 @@ export class ControlApiService {
       }));
   }
 
-  public terminateMongooseRun(runId: string): Observable<string> { 
+  public terminateMongooseRun(runId: string): Observable<string> {
     const terminationHeaders = {
       // NOTE: Termination is completed using'If-Match' header. 
       // Matching by run ID.
       'If-Match': `${runId}`
     }
 
-    const terminationRequestOptions = { 
-      headers: new HttpHeaders(terminationHeaders), 
+    const terminationRequestOptions = {
+      headers: new HttpHeaders(terminationHeaders),
       observe: 'response' as 'body'
     }
 
     return this.http.delete(`${this.mongooseHostIp}/${MongooseApi.RunApi.RUN_ENDPOINT}`, terminationRequestOptions).pipe(
-      map((response: any) => { 
-        if (response.status == Constants.HttpStatus.OK) { 
+      map((response: any) => {
+        if (response.status == Constants.HttpStatus.OK) {
           return `Run ${runId} has been successfully terminated.`;
         }
         return `Run ${runId} hasn't been terminated. Detauls: ${response}`;
@@ -82,27 +82,27 @@ export class ControlApiService {
     var mongooseConfigurationHeaders = new HttpHeaders();
     mongooseConfigurationHeaders.append('Accept', 'application/json');
 
-    return this.http.get(mongooseAddress + configEndpoint, {headers: mongooseConfigurationHeaders});
+    return this.http.get(mongooseAddress + configEndpoint, { headers: mongooseConfigurationHeaders });
   }
 
-  public getStatusForMongooseRun(runId: string): Observable<MongooseRunStatus> { 
+  public getStatusForMongooseRun(runId: string): Observable<MongooseRunStatus> {
 
     const requestRunStatusHeaders = {
       // NOTE: 'If-Match' header should contain Mongoose run ID, NOT load step ID.
       'If-Match': `${runId}`
     }
 
-    const runStatusRequestOptions = { 
-      headers: new HttpHeaders(requestRunStatusHeaders), 
+    const runStatusRequestOptions = {
+      headers: new HttpHeaders(requestRunStatusHeaders),
       observe: 'response' as 'body'
     }
 
     return this.http.get(`${this.mongooseHostIp}/${MongooseApi.RunApi.RUN_ENDPOINT}`, runStatusRequestOptions).pipe(
-      map((runStatusResponse: any) => { 
+      map((runStatusResponse: any) => {
         let responseStatusCode = runStatusResponse.status;
 
-        if (responseStatusCode == undefined) { 
-          return MongooseRunStatus.Unavailable; 
+        if (responseStatusCode == undefined) {
+          return MongooseRunStatus.Unavailable;
         }
 
         let isRunActive: boolean = (responseStatusCode == Constants.HttpStatus.OK);

--- a/console/src/app/core/services/control-api/control-api.service.ts
+++ b/console/src/app/core/services/control-api/control-api.service.ts
@@ -78,7 +78,7 @@ export class ControlApiService {
 
   public getStatusForMongooseRun(runEntryNode: MongooseRunEntryNode): Observable<MongooseRunStatus> {
 
-    if (runEntryNode.getEntryNodeAddress() == "address-not-exist") {
+    if (runEntryNode.getEntryNodeAddress() == MongooseRunEntryNode.ADDRESS_NOT_EXIST) {
       return (of(MongooseRunStatus.Unavailable));
     }
 

--- a/console/src/app/core/services/control-api/control-api.service.ts
+++ b/console/src/app/core/services/control-api/control-api.service.ts
@@ -37,7 +37,7 @@ export class ControlApiService {
     let configurationFormData = this.getFormDataArgumentsForMongooseRun(mongooseJsonConfiguration, javaScriptScenario);
 
 
-    return this.http.post(`${Constants.Http.HTTP_PREFIX}${entryNodeAddress}` + "/run", configurationFormData, { observe: "response" }).pipe(
+    return this.http.post(`${Constants.Http.HTTP_PREFIX}${entryNodeAddress}/${MongooseApi.RunApi.RUN_ENDPOINT}`, configurationFormData, { observe: "response" }).pipe(
       map(runResponse => {
         let runId = runResponse.headers.get(MongooseApi.Headers.ETAG);
         return runId;
@@ -77,6 +77,10 @@ export class ControlApiService {
   }
 
   public getStatusForMongooseRun(runEntryNode: MongooseRunEntryNode): Observable<MongooseRunStatus> {
+
+    if (runEntryNode.getEntryNodeAddress() == "address-not-exist") {
+      return (of(MongooseRunStatus.Unavailable));
+    }
 
     const requestRunStatusHeaders = {
       // NOTE: 'If-Match' header should contain Mongoose run ID, NOT load step ID.

--- a/console/src/app/core/services/control-api/control-api.service.ts
+++ b/console/src/app/core/services/control-api/control-api.service.ts
@@ -29,21 +29,11 @@ export class ControlApiService {
     return this.mongooseHostIp;
   }
 
-  public runMongoose(entryNodeAddress: string, mongooseJsonConfiguration: Object, javaScriptScenario: String = ""): Observable<any> {
+  public runMongoose(entryNodeAddress: string, mongooseJsonConfiguration: Object = "", javaScriptScenario: String = ""): Observable<any> {
 
     // NOTE: Using JSON.stirngly(...) to pass Scenario as a HTTP parameter. It could contains multiple quotes, JSON.stringfy(...) handles it well. 
 
-    let configurationFormData = new FormData();
-
-    let mongooseConfigurationBlob = new Blob([JSON.stringify(mongooseJsonConfiguration)], { type: "application/json" });
-    configurationFormData.append('defaults', mongooseConfigurationBlob);
-
-    const emptyValue = "";
-    if (javaScriptScenario != emptyValue) {
-      javaScriptScenario = JSON.stringify(javaScriptScenario);
-      let mongooseRunScenarioBlob = new Blob([JSON.stringify(javaScriptScenario)], { type: "text/plain" });
-      configurationFormData.append('scenario', mongooseRunScenarioBlob);
-    }
+    let configurationFormData = this.getFormDataArgumentsForMongooseRun(mongooseJsonConfiguration, javaScriptScenario);
 
 
     return this.http.post(`${Constants.Http.HTTP_PREFIX}${entryNodeAddress}` + "/run", configurationFormData, { observe: "response" }).pipe(
@@ -113,6 +103,26 @@ export class ControlApiService {
 
 
   // MARK: - Private
+
+
+  // NOTE: Mongoose run accepts parameters as form data (configuration file, scenario file, etc.). The function ...
+  // ... adds the parameters into FormData object.
+  private getFormDataArgumentsForMongooseRun(mongooseRunConfiguration: Object, mongooseRunScenario: Object): FormData {
+    const emptyValue = "";
+
+    let configurationFormData = new FormData();
+    if (mongooseRunConfiguration != emptyValue) {
+      let mongooseConfigurationBlob = new Blob([JSON.stringify(mongooseRunConfiguration)], { type: "application/json" });
+      configurationFormData.append('defaults', mongooseConfigurationBlob);
+    }
+
+    if (mongooseRunScenario != emptyValue) {
+      let mongooseRunScenarioBlob = new Blob([JSON.stringify(mongooseRunScenario)], { type: "text/plain" });
+      configurationFormData.append('scenario', mongooseRunScenarioBlob);
+    }
+
+    return configurationFormData;
+  }
 
   private getHttpHeaderForJsonFile(): HttpHeaders {
     var httpHeadersForMongooseRun = new HttpHeaders();

--- a/console/src/app/core/services/control-api/control-api.service.ts
+++ b/console/src/app/core/services/control-api/control-api.service.ts
@@ -6,6 +6,7 @@ import { Observable, of } from 'rxjs';
 import { map, retry } from 'rxjs/operators';
 import { environment } from 'src/environments/environment';
 import { MongooseRunStatus } from '../../models/mongoose-run-status';
+import { MongooseRunEntryNode } from '../local-storage-service/MongooseRunEntryNode';
 
 @Injectable({
   providedIn: 'root'
@@ -75,11 +76,11 @@ export class ControlApiService {
     return this.http.get(mongooseAddress + configEndpoint, { headers: mongooseConfigurationHeaders });
   }
 
-  public getStatusForMongooseRun(runId: string): Observable<MongooseRunStatus> {
+  public getStatusForMongooseRun(runEntryNode: MongooseRunEntryNode): Observable<MongooseRunStatus> {
 
     const requestRunStatusHeaders = {
       // NOTE: 'If-Match' header should contain Mongoose run ID, NOT load step ID.
-      'If-Match': `${runId}`
+      'If-Match': `${runEntryNode.getRunId()}`
     }
 
     const runStatusRequestOptions = {
@@ -87,7 +88,7 @@ export class ControlApiService {
       observe: 'response' as 'body'
     }
 
-    return this.http.get(`${this.mongooseHostIp}/${MongooseApi.RunApi.RUN_ENDPOINT}`, runStatusRequestOptions).pipe(
+    return this.http.get(`http://${runEntryNode.getEntryNodeAddress()}/${MongooseApi.RunApi.RUN_ENDPOINT}`, runStatusRequestOptions).pipe(
       map((runStatusResponse: any) => {
         let responseStatusCode = runStatusResponse.status;
 

--- a/console/src/app/core/services/control-api/control-api.service.ts
+++ b/console/src/app/core/services/control-api/control-api.service.ts
@@ -44,7 +44,7 @@ export class ControlApiService {
       }));
   }
 
-  public terminateMongooseRun(runId: string): Observable<string> {
+  public terminateMongooseRun(mongooseRunEntryNodeAddress: string, runId: string): Observable<string> {
     const terminationHeaders = {
       // NOTE: Termination is completed using'If-Match' header. 
       // Matching by run ID.
@@ -56,7 +56,7 @@ export class ControlApiService {
       observe: 'response' as 'body'
     }
 
-    return this.http.delete(`${this.mongooseHostIp}/${MongooseApi.RunApi.RUN_ENDPOINT}`, terminationRequestOptions).pipe(
+    return this.http.delete(`${Constants.Http.HTTP_PREFIX}${mongooseRunEntryNodeAddress}/${MongooseApi.RunApi.RUN_ENDPOINT}`, terminationRequestOptions).pipe(
       map((response: any) => {
         if (response.status == Constants.HttpStatus.OK) {
           return `Run ${runId} has been successfully terminated.`;

--- a/console/src/app/core/services/control-api/control-api.service.ts
+++ b/console/src/app/core/services/control-api/control-api.service.ts
@@ -32,15 +32,20 @@ export class ControlApiService {
   public runMongoose(entryNodeAddress: string, mongooseJsonConfiguration: Object, javaScriptScenario: String = ""): Observable<any> {
 
     // NOTE: Using JSON.stirngly(...) to pass Scenario as a HTTP parameter. It could contains multiple quotes, JSON.stringfy(...) handles it well. 
-    javaScriptScenario = JSON.stringify(javaScriptScenario);
 
     let configurationFormData = new FormData();
-    configurationFormData.append('defaults', new Blob([JSON.stringify(mongooseJsonConfiguration)], {type: "application/json"}));
 
-    // let scenarioFormData = new FormData();
-    configurationFormData.append('scenario', new Blob([JSON.stringify(javaScriptScenario)], {type: "text/plain"}));
+    let mongooseConfigurationBlob = new Blob([JSON.stringify(mongooseJsonConfiguration)], {type: "application/json"});
+    configurationFormData.append('defaults', mongooseConfigurationBlob);
+    
+    const emptyValue = "";
+    if (javaScriptScenario != emptyValue) { 
+      javaScriptScenario = JSON.stringify(javaScriptScenario);
+      let mongooseRunScenarioBlob = new Blob([JSON.stringify(javaScriptScenario)], {type: "text/plain"});
+      configurationFormData.append('scenario', mongooseRunScenarioBlob);
+    }
+   
 
-    // let mongooseRunArguments = [configurationFormData, scenarioFormData];
     return this.http.post(`${Constants.Http.HTTP_PREFIX}${entryNodeAddress}` + "/run", configurationFormData, { observe: "response" }).pipe(
       map(runResponse => {
         let runId = runResponse.headers.get(MongooseApi.Headers.ETAG);

--- a/console/src/app/core/services/local-storage-service/MongooseRunEntryNode.ts
+++ b/console/src/app/core/services/local-storage-service/MongooseRunEntryNode.ts
@@ -1,4 +1,5 @@
 export class MongooseRunEntryNode { 
+    static readonly ADDRESS_NOT_EXIST = "address-not-exist";
 
     private entryNodeAddress: string;
     private runId: string;

--- a/console/src/app/core/services/local-storage-service/MongooseRunEntryNode.ts
+++ b/console/src/app/core/services/local-storage-service/MongooseRunEntryNode.ts
@@ -1,0 +1,18 @@
+export class MongooseRunEntryNode { 
+
+    private entryNodeAddress: string;
+    private runId: string;
+ 
+    constructor(entryNodeAddress: string, runId: string) { 
+        this.entryNodeAddress = entryNodeAddress;
+        this.runId = runId;
+    }
+
+    public getRunId(): string { 
+        return this.runId;
+    }
+
+    public getEntryNodeAddress(): string { 
+        return this.entryNodeAddress;
+    }
+}

--- a/console/src/app/core/services/local-storage-service/local-storage.service.spec.ts
+++ b/console/src/app/core/services/local-storage-service/local-storage.service.spec.ts
@@ -1,0 +1,12 @@
+import { TestBed } from '@angular/core/testing';
+
+import { LocalStorageService } from './local-storage.service';
+
+describe('LocalStorageService', () => {
+  beforeEach(() => TestBed.configureTestingModule({}));
+
+  it('should be created', () => {
+    const service: LocalStorageService = TestBed.get(LocalStorageService);
+    expect(service).toBeTruthy();
+  });
+});

--- a/console/src/app/core/services/local-storage-service/local-storage.service.ts
+++ b/console/src/app/core/services/local-storage-service/local-storage.service.ts
@@ -23,9 +23,21 @@ export class LocalStorageService {
 
   public getEntryNodeAddressForRunId(runId: string): MongooseRunEntryNode { 
     let currentEntryNodeMap: MongooseRunEntryNode[] = this.storage.get(this.ENTRY_NODE_TO_RUN_ID_MAP_STORAGE_KEY) || [];
-    let matchingMongooseRunEntryNode = currentEntryNodeMap.find(entry => {
-      return (entry.getRunId() == runId);
-    });
-    return matchingMongooseRunEntryNode;
+
+    const firstFoundEntryIndex = 0;
+    let matchingEntryFromLocalStorage: any = currentEntryNodeMap.filter((entry: any) => { 
+      let entryRunId = entry.runId;
+      if (entryRunId == undefined) { 
+        return false; 
+      }
+      return (entry.runId == runId);
+    })[firstFoundEntryIndex];
+
+    let matchingEntryNodeAddress = matchingEntryFromLocalStorage.runEntryNode; 
+    if (matchingEntryNodeAddress == undefined) { 
+      throw new Error(`Entry node address for run ID ${runId} doesn't exist within local storage.`);
+    };
+
+    return new MongooseRunEntryNode(matchingEntryNodeAddress, runId);
   }
 }

--- a/console/src/app/core/services/local-storage-service/local-storage.service.ts
+++ b/console/src/app/core/services/local-storage-service/local-storage.service.ts
@@ -13,6 +13,8 @@ export class LocalStorageService {
 
   constructor(@Inject(LOCAL_STORAGE) private storage: StorageService) { }
 
+  // MARK: - Public 
+  
   public saveToLocalStorage(runEntryNodeAddress: string, runId: string) {
     const currentEntryNodeMap = this.storage.get(this.ENTRY_NODE_TO_RUN_ID_MAP_STORAGE_KEY) || [];
     let newMongooseRunInstance = new MongooseRunEntryNode(runEntryNodeAddress, runId);
@@ -23,17 +25,26 @@ export class LocalStorageService {
 
   public getEntryNodeAddressForRunId(runId: string): MongooseRunEntryNode {
     let currentEntryNodeMap: MongooseRunEntryNode[] = this.storage.get(this.ENTRY_NODE_TO_RUN_ID_MAP_STORAGE_KEY) || [];
-
     const firstFoundEntryIndex = 0;
     let matchingEntryFromLocalStorage: any = currentEntryNodeMap.filter((entry: any) => {
       return (entry.runId == runId);
     })[firstFoundEntryIndex] || "";
 
-    let matchingEntryNodeAddress = matchingEntryFromLocalStorage.runEntryNode;
+    let matchingEntryNodeAddress = this.getEntryNodeAddressFromObject(matchingEntryFromLocalStorage);
     if (matchingEntryNodeAddress == undefined) {
       throw new Error(`Entry node address for run ID ${runId} doesn't exist within local storage.`);
     };
 
     return new MongooseRunEntryNode(matchingEntryNodeAddress, runId);
+  }
+
+  // MARK: - Private 
+
+  private getEntryNodeAddressFromObject(object: any): string { 
+    let nodeAddress =  object.entryNodeAddress; 
+    if (nodeAddress == undefined) { 
+      throw new Error(`Unable to get entry node address from local storage entry.`)
+    }
+    return nodeAddress;
   }
 }

--- a/console/src/app/core/services/local-storage-service/local-storage.service.ts
+++ b/console/src/app/core/services/local-storage-service/local-storage.service.ts
@@ -1,0 +1,26 @@
+import { Inject, Injectable } from '@angular/core';
+import { LOCAL_STORAGE, StorageService } from 'ngx-webstorage-service';
+
+
+@Injectable({
+  providedIn: 'root'
+})
+export class LocalStorageService {
+
+  readonly STORAGE_KEY = "mongoose-darzee";
+
+
+  constructor(@Inject(LOCAL_STORAGE) private storage: StorageService) { }
+
+  public saveToLocalStorage(runEntryNode: string, runId: string) { 
+    const currentEntryNodeMap = this.storage.get(this.STORAGE_KEY) || [];
+    console.log(`currentEntryNodeMap: ${JSON.stringify(currentEntryNodeMap)}`);
+    currentEntryNodeMap.push({
+      runEntryNode: `${runEntryNode}`,
+      runId: `${runId}`
+    });
+
+    this.storage.set(this.STORAGE_KEY, currentEntryNodeMap);
+    console.log(`updated currentEntryNodeMap: ${JSON.stringify(currentEntryNodeMap)}`);
+  }
+}

--- a/console/src/app/core/services/local-storage-service/local-storage.service.ts
+++ b/console/src/app/core/services/local-storage-service/local-storage.service.ts
@@ -13,7 +13,7 @@ export class LocalStorageService {
 
   constructor(@Inject(LOCAL_STORAGE) private storage: StorageService) { }
 
-  public saveToLocalStorage(runEntryNodeAddress: string, runId: string) { 
+  public saveToLocalStorage(runEntryNodeAddress: string, runId: string) {
     const currentEntryNodeMap = this.storage.get(this.ENTRY_NODE_TO_RUN_ID_MAP_STORAGE_KEY) || [];
     let newMongooseRunInstance = new MongooseRunEntryNode(runEntryNodeAddress, runId);
     currentEntryNodeMap.push(newMongooseRunInstance);
@@ -21,20 +21,16 @@ export class LocalStorageService {
     this.storage.set(this.ENTRY_NODE_TO_RUN_ID_MAP_STORAGE_KEY, currentEntryNodeMap);
   }
 
-  public getEntryNodeAddressForRunId(runId: string): MongooseRunEntryNode { 
+  public getEntryNodeAddressForRunId(runId: string): MongooseRunEntryNode {
     let currentEntryNodeMap: MongooseRunEntryNode[] = this.storage.get(this.ENTRY_NODE_TO_RUN_ID_MAP_STORAGE_KEY) || [];
 
     const firstFoundEntryIndex = 0;
-    let matchingEntryFromLocalStorage: any = currentEntryNodeMap.filter((entry: any) => { 
-      let entryRunId = entry.runId;
-      if (entryRunId == undefined) { 
-        return false; 
-      }
+    let matchingEntryFromLocalStorage: any = currentEntryNodeMap.filter((entry: any) => {
       return (entry.runId == runId);
-    })[firstFoundEntryIndex];
+    })[firstFoundEntryIndex] || "";
 
-    let matchingEntryNodeAddress = matchingEntryFromLocalStorage.runEntryNode; 
-    if (matchingEntryNodeAddress == undefined) { 
+    let matchingEntryNodeAddress = matchingEntryFromLocalStorage.runEntryNode;
+    if (matchingEntryNodeAddress == undefined) {
       throw new Error(`Entry node address for run ID ${runId} doesn't exist within local storage.`);
     };
 

--- a/console/src/app/core/services/local-storage-service/local-storage.service.ts
+++ b/console/src/app/core/services/local-storage-service/local-storage.service.ts
@@ -7,20 +7,19 @@ import { LOCAL_STORAGE, StorageService } from 'ngx-webstorage-service';
 })
 export class LocalStorageService {
 
-  readonly STORAGE_KEY = "mongoose-darzee";
+  readonly ENTRY_NODE_TO_RUN_ID_MAP_STORAGE_KEY = "mongoose-darzee-entry-node-to-run-id-map";
 
 
   constructor(@Inject(LOCAL_STORAGE) private storage: StorageService) { }
 
   public saveToLocalStorage(runEntryNode: string, runId: string) { 
-    const currentEntryNodeMap = this.storage.get(this.STORAGE_KEY) || [];
-    console.log(`currentEntryNodeMap: ${JSON.stringify(currentEntryNodeMap)}`);
+    const currentEntryNodeMap = this.storage.get(this.ENTRY_NODE_TO_RUN_ID_MAP_STORAGE_KEY) || [];
     currentEntryNodeMap.push({
       runEntryNode: `${runEntryNode}`,
       runId: `${runId}`
     });
 
-    this.storage.set(this.STORAGE_KEY, currentEntryNodeMap);
+    this.storage.set(this.ENTRY_NODE_TO_RUN_ID_MAP_STORAGE_KEY, currentEntryNodeMap);
     console.log(`updated currentEntryNodeMap: ${JSON.stringify(currentEntryNodeMap)}`);
   }
 }

--- a/console/src/app/core/services/local-storage-service/local-storage.service.ts
+++ b/console/src/app/core/services/local-storage-service/local-storage.service.ts
@@ -21,11 +21,11 @@ export class LocalStorageService {
     this.storage.set(this.ENTRY_NODE_TO_RUN_ID_MAP_STORAGE_KEY, currentEntryNodeMap);
   }
 
-  public getEntryNodeAddressForRunId(runId: string): string { 
+  public getEntryNodeAddressForRunId(runId: string): MongooseRunEntryNode { 
     let currentEntryNodeMap: MongooseRunEntryNode[] = this.storage.get(this.ENTRY_NODE_TO_RUN_ID_MAP_STORAGE_KEY) || [];
     let matchingMongooseRunEntryNode = currentEntryNodeMap.find(entry => {
       return (entry.getRunId() == runId);
     });
-    return matchingMongooseRunEntryNode.getEntryNodeAddress();
+    return matchingMongooseRunEntryNode;
   }
 }

--- a/console/src/app/core/services/local-storage-service/local-storage.service.ts
+++ b/console/src/app/core/services/local-storage-service/local-storage.service.ts
@@ -1,5 +1,6 @@
 import { Inject, Injectable } from '@angular/core';
 import { LOCAL_STORAGE, StorageService } from 'ngx-webstorage-service';
+import { MongooseRunEntryNode } from './MongooseRunEntryNode';
 
 
 @Injectable({
@@ -12,14 +13,19 @@ export class LocalStorageService {
 
   constructor(@Inject(LOCAL_STORAGE) private storage: StorageService) { }
 
-  public saveToLocalStorage(runEntryNode: string, runId: string) { 
+  public saveToLocalStorage(runEntryNodeAddress: string, runId: string) { 
     const currentEntryNodeMap = this.storage.get(this.ENTRY_NODE_TO_RUN_ID_MAP_STORAGE_KEY) || [];
-    currentEntryNodeMap.push({
-      runEntryNode: `${runEntryNode}`,
-      runId: `${runId}`
-    });
+    let newMongooseRunInstance = new MongooseRunEntryNode(runEntryNodeAddress, runId);
+    currentEntryNodeMap.push(newMongooseRunInstance);
 
     this.storage.set(this.ENTRY_NODE_TO_RUN_ID_MAP_STORAGE_KEY, currentEntryNodeMap);
-    console.log(`updated currentEntryNodeMap: ${JSON.stringify(currentEntryNodeMap)}`);
+  }
+
+  public getEntryNodeAddressForRunId(runId: string): string { 
+    let currentEntryNodeMap: MongooseRunEntryNode[] = this.storage.get(this.ENTRY_NODE_TO_RUN_ID_MAP_STORAGE_KEY) || [];
+    let matchingMongooseRunEntryNode = currentEntryNodeMap.find(entry => {
+      return (entry.getRunId() == runId);
+    });
+    return matchingMongooseRunEntryNode.getEntryNodeAddress();
   }
 }

--- a/console/src/app/core/services/mongoose-set-up-service/mongoose-set-up-info.model.ts
+++ b/console/src/app/core/services/mongoose-set-up-service/mongoose-set-up-info.model.ts
@@ -13,6 +13,21 @@ export class MongooseSetupInfoModel {
     private readonly DEFAULT_CONFIGURATION = "";
     private readonly DEFAULT_SCENARIO = "Load.run();";
 
+     // MARK: - Constructor
+     constructor(runNodes: MongooseRunNode[] = [], configuration: any = undefined, runScenario: String = "") {
+        this.runNodes = runNodes;
+        this.configuration = configuration;
+        this.runScenario = runScenario;
+
+        if (this.configuration == undefined) {
+            this.configuration = this.DEFAULT_CONFIGURATION;
+        }
+
+        if (runScenario = "") {
+            this.runScenario = this.DEFAULT_SCENARIO;
+        }
+    }
+
     // MARK: Getters & Setters
 
     public setLoadStepId(loadStepId: String) {
@@ -38,8 +53,12 @@ export class MongooseSetupInfoModel {
         this.configuration = configuration;
     }
 
-    public getRunNodes(): MongooseRunNode[] {
+    public getFullRunNodesList(): MongooseRunNode[] {
         return this.runNodes;
+    }
+
+    public getSlaveNodesList(entryNode: MongooseRunNode): MongooseRunNode[] { 
+        return this.runNodes.filter(node => { return (entryNode.getResourceLocation() != node.getResourceLocation())});
     }
 
     public getConfiguration(): any {
@@ -50,11 +69,16 @@ export class MongooseSetupInfoModel {
         return this.runScenario;
     }
 
-    public getStringfiedRunNodes(): String[] {
+    public getStringifiedNodesForDistributedMode(entryNode: MongooseRunNode): String[] {
         let stringfiedRunNodes: String[] = [];
         this.runNodes.forEach(runNode => {
+            let isNodeEntry = (runNode.getResourceLocation() == entryNode.getResourceLocation());
+            if (isNodeEntry) { 
+                // NOTE: Entry node shouldn't be added as a slave node into Mongoose's cofiguration.
+                return; 
+            }
             stringfiedRunNodes.push(runNode.toString());
-        })
+        });
         return stringfiedRunNodes;
     }
 
@@ -69,20 +93,7 @@ export class MongooseSetupInfoModel {
         })
     }
 
-    // MARK: - Constructor
-    constructor(runNodes: MongooseRunNode[] = [], configuration: any = undefined, runScenario: String = "") {
-        this.runNodes = runNodes;
-        this.configuration = configuration;
-        this.runScenario = runScenario;
-
-        if (this.configuration == undefined) {
-            this.configuration = this.DEFAULT_CONFIGURATION;
-        }
-
-        if (runScenario = "") {
-            this.runScenario = this.DEFAULT_SCENARIO;
-        }
-    }
+   
 
     // MARK: - Public 
 

--- a/console/src/app/core/services/mongoose-set-up-service/mongoose-set-up-info.model.ts
+++ b/console/src/app/core/services/mongoose-set-up-service/mongoose-set-up-info.model.ts
@@ -69,14 +69,9 @@ export class MongooseSetupInfoModel {
         return this.runScenario;
     }
 
-    public getStringifiedNodesForDistributedMode(entryNode: MongooseRunNode): String[] {
+    public getStringifiedNodesForDistributedMode(): String[] {
         let stringfiedRunNodes: String[] = [];
         this.runNodes.forEach(runNode => {
-            let isNodeEntry = (runNode.getResourceLocation() == entryNode.getResourceLocation());
-            if (isNodeEntry) { 
-                // NOTE: Entry node shouldn't be added as a slave node into Mongoose's cofiguration.
-                return; 
-            }
             stringfiedRunNodes.push(runNode.toString());
         });
         return stringfiedRunNodes;

--- a/console/src/app/core/services/mongoose-set-up-service/mongoose-set-up-info.model.ts
+++ b/console/src/app/core/services/mongoose-set-up-service/mongoose-set-up-info.model.ts
@@ -69,10 +69,11 @@ export class MongooseSetupInfoModel {
         return this.runScenario;
     }
 
-    public getStringifiedNodesForDistributedMode(): String[] {
-        let stringfiedRunNodes: String[] = [];
+    public getStringifiedNodesForDistributedMode(): string[] {
+        let stringfiedRunNodes: string[] = [];
         this.runNodes.forEach(runNode => {
-            stringfiedRunNodes.push(runNode.toString());
+            let nodeAddress: string = runNode.toString() as string; 
+            stringfiedRunNodes.push(nodeAddress);
         });
         return stringfiedRunNodes;
     }

--- a/console/src/app/core/services/mongoose-set-up-service/mongoose-set-up-info.model.ts
+++ b/console/src/app/core/services/mongoose-set-up-service/mongoose-set-up-info.model.ts
@@ -98,9 +98,13 @@ export class MongooseSetupInfoModel {
         }
     }
 
-    // MARK: - Private 
+    public removeRunNode(runNode: MongooseRunNode) {
+        this.runNodes = this.runNodes.filter(node => {
+            return (node.getResourceLocation() != runNode.getResourceLocation());
+        })
+    }
 
-    private isNodeAlreadyExist(node: MongooseRunNode) {
+    public isNodeAlreadyExist(node: MongooseRunNode) {
         let isNodeExist = false;
         this.runNodes.forEach(savedNode => {
             isNodeExist = ((savedNode.getResourceLocation() == node.getResourceLocation()) && (savedNode.getResourceType() == savedNode.getResourceType()));
@@ -110,4 +114,7 @@ export class MongooseSetupInfoModel {
         });
         return isNodeExist;
     }
+    // MARK: - Private 
+
+
 }

--- a/console/src/app/core/services/mongoose-set-up-service/mongoose-set-up.service.ts
+++ b/console/src/app/core/services/mongoose-set-up-service/mongoose-set-up.service.ts
@@ -119,10 +119,9 @@ export class MongooseSetUpService {
     this.http.get(environment.prometheusConfigPath, { responseType: 'text' }).subscribe((configurationFileContent: Object) => {
       let prometheusConfigurationEditor: PrometheusConfigurationEditor = new PrometheusConfigurationEditor(configurationFileContent);
 
-      let entryNode = this.getMongooseEntryNode();
-      let mongooseSlaveNodesForDistributedMode = this.mongooseSetupInfoModel.getStringifiedNodesForDistributedMode(entryNode);
-
-      let updatedConfiguration = prometheusConfigurationEditor.addTargetsToConfiguration(mongooseSlaveNodesForDistributedMode);
+      let mongooseRunNodes = this.mongooseSetupInfoModel.getStringifiedNodesForDistributedMode();
+      let updatedConfiguration = prometheusConfigurationEditor.addTargetsToConfiguration(mongooseRunNodes);
+      
       // NOTE: Saving prometheus configuration in .yml file. 
       let prometheusConfigFileName = `${Constants.FileNames.PROMETHEUS_CONFIGURATION}.${FileFormat.YML}`;
       this.containerServerService.saveFile(prometheusConfigFileName, updatedConfiguration as string).subscribe(response => {

--- a/console/src/app/core/services/mongoose-set-up-service/mongoose-set-up.service.ts
+++ b/console/src/app/core/services/mongoose-set-up-service/mongoose-set-up.service.ts
@@ -93,11 +93,11 @@ export class MongooseSetUpService {
   }
 
 
-  public runMongoose(): Observable<String> {
+  public runMongoose(entryNode: MongooseRunNode): Observable<String> {
     // NOTE: Updating Prometheus configuration with respect to Mongoose Run nodes. 
     this.updatePrometheusConfiguration();
     // NOTE: you can get related load step ID from mongoose setup model here. 
-    return this.controlApiService.runMongoose(this.mongooseSetupInfoModel.getConfiguration(), this.mongooseSetupInfoModel.getRunScenario()).pipe(
+    return this.controlApiService.runMongoose(entryNode.getResourceLocation(), this.mongooseSetupInfoModel.getConfiguration(), this.mongooseSetupInfoModel.getRunScenario()).pipe(
       map(runId => {
         this.mongooseSetupInfoModel.setLoadStepId(runId);
         return runId;
@@ -121,7 +121,7 @@ export class MongooseSetUpService {
 
       let mongooseRunNodes = this.mongooseSetupInfoModel.getStringifiedNodesForDistributedMode();
       let updatedConfiguration = prometheusConfigurationEditor.addTargetsToConfiguration(mongooseRunNodes);
-      
+
       // NOTE: Saving prometheus configuration in .yml file. 
       let prometheusConfigFileName = `${Constants.FileNames.PROMETHEUS_CONFIGURATION}.${FileFormat.YML}`;
       this.containerServerService.saveFile(prometheusConfigFileName, updatedConfiguration as string).subscribe(response => {

--- a/console/src/app/core/services/mongoose-set-up-service/mongoose-set-up.service.ts
+++ b/console/src/app/core/services/mongoose-set-up-service/mongoose-set-up.service.ts
@@ -26,9 +26,6 @@ export class MongooseSetUpService {
     private http: HttpClient,
     private localStorageService: LocalStorageService) {
 
-    let currentNodesList: string[] = this.mongooseSetupInfoModel.getStringifiedNodesForDistributedMode() || [];
-    this.addNodesToPrometheusTargets(currentNodesList);
-
     this.mongooseSetupInfoModel = new MongooseSetupInfoModel();
     this.controlApiService.getMongooseConfiguration(this.controlApiService.getMongooseIp())
       .subscribe((configuration: any) => {

--- a/console/src/app/core/services/mongoose-set-up-service/mongoose-set-up.service.ts
+++ b/console/src/app/core/services/mongoose-set-up-service/mongoose-set-up.service.ts
@@ -26,7 +26,7 @@ export class MongooseSetUpService {
     private http: HttpClient,
     private localStorageService: LocalStorageService) {
 
-    let currentNodesList: string[] = this.mongooseSetupInfoModel.getStringifiedNodesForDistributedMode() || []; 
+    let currentNodesList: string[] = this.mongooseSetupInfoModel.getStringifiedNodesForDistributedMode() || [];
     this.addNodesToPrometheusTargets(currentNodesList);
 
     this.mongooseSetupInfoModel = new MongooseSetupInfoModel();

--- a/console/src/app/core/services/mongoose-set-up-service/mongoose-set-up.service.ts
+++ b/console/src/app/core/services/mongoose-set-up-service/mongoose-set-up.service.ts
@@ -12,6 +12,7 @@ import { map } from 'rxjs/operators';
 import { MongooseRunNode } from '../../models/mongoose-run-node.model';
 import { ResourceLocatorType } from '../../models/address-type';
 import { MongooseConfigurationParser } from '../../models/mongoose-configuration-parser';
+import { LocalStorageService } from '../local-storage-service/local-storage.service';
 
 @Injectable({
   providedIn: 'root'
@@ -22,7 +23,8 @@ export class MongooseSetUpService {
 
   constructor(private controlApiService: ControlApiService,
     private containerServerService: ContainerServerService,
-    private http: HttpClient) {
+    private http: HttpClient,
+    private localStorageService: LocalStorageService) {
 
     this.updatePrometheusConfiguration();
 
@@ -100,6 +102,7 @@ export class MongooseSetUpService {
     return this.controlApiService.runMongoose(entryNode.getResourceLocation(), this.mongooseSetupInfoModel.getConfiguration(), this.mongooseSetupInfoModel.getRunScenario()).pipe(
       map(runId => {
         this.mongooseSetupInfoModel.setLoadStepId(runId);
+        this.localStorageService.saveToLocalStorage(entryNode.getResourceLocation(), runId);
         return runId;
       })
     );

--- a/console/src/app/core/services/mongoose-set-up-service/mongoose-set-up.service.ts
+++ b/console/src/app/core/services/mongoose-set-up-service/mongoose-set-up.service.ts
@@ -72,8 +72,18 @@ export class MongooseSetUpService {
     return this.mongooseSetupInfoModel.getRunNodes();
   }
 
+  public isNodeExist(node: MongooseRunNode): boolean { 
+    return this.mongooseSetupInfoModel.isNodeAlreadyExist(node);
+  }
+
+  // NOTE: Adding Mongoose nodes (while node selection)
   public addNode(node: MongooseRunNode) {
+    console.log(`node ${node.getResourceLocation()} will be eventually added.`)
     this.mongooseSetupInfoModel.addRunNode(node);
+  }
+
+  public removeNode(node: MongooseRunNode) { 
+    this.mongooseSetupInfoModel.removeRunNode(node);
   }
 
 

--- a/console/src/app/core/services/mongoose-set-up-service/mongoose-set-up.service.ts
+++ b/console/src/app/core/services/mongoose-set-up-service/mongoose-set-up.service.ts
@@ -36,8 +36,8 @@ export class MongooseSetUpService {
 
   // MARK: - Getters & Setters 
 
-  public getMongooseConfigurationForSetUp(): Observable<any> {
-    let mongooseTargetAddress = `${Constants.Http.HTTP_PREFIX}${environment.mongooseIp}:` + `${environment.mongoosePort}`;
+  public getMongooseConfigurationForSetUp(entryNode: MongooseRunNode): Observable<any> {
+    let mongooseTargetAddress = `${Constants.Http.HTTP_PREFIX}${entryNode.getResourceLocation()}`;
     return this.controlApiService.getMongooseConfiguration(mongooseTargetAddress).pipe(
       map(
         (configuration: any) => {
@@ -74,6 +74,12 @@ export class MongooseSetUpService {
 
   public isNodeExist(node: MongooseRunNode): boolean { 
     return this.mongooseSetupInfoModel.isNodeAlreadyExist(node);
+  }
+
+  public getMongooseEntryNode(): MongooseRunNode { 
+    // NOTE: First node from the list counts as the entry one. 
+    const firstNodeIndex = 0;
+    return this.mongooseSetupInfoModel.getRunNodes()[firstNodeIndex];
   }
 
   // NOTE: Adding Mongoose nodes (while node selection)

--- a/console/src/app/core/services/monitoring-api/monitoring-api.service.ts
+++ b/console/src/app/core/services/monitoring-api/monitoring-api.service.ts
@@ -18,7 +18,6 @@ import { MongooseRunEntryNode } from "../local-storage-service/MongooseRunEntryN
 })
 export class MonitoringApiService {
 
-  private readonly MONGOOSE_HTTP_ADDRESS = Constants.Http.HTTP_PREFIX + Constants.Configuration.MONGOOSE_HOST_IP;
   private currentMongooseRunRecords$: BehaviorSubject<MongooseRunRecord[]> = new BehaviorSubject<MongooseRunRecord[]>([]);
 
   // NOTE: availableLogs is a list of logs provided by Mongoose. Key is REST API's endpoint for fetching the log, ...

--- a/console/src/app/core/services/monitoring-api/monitoring-api.service.ts
+++ b/console/src/app/core/services/monitoring-api/monitoring-api.service.ts
@@ -9,6 +9,7 @@ import { MongooseMetrics } from "../mongoose-api-models/MongooseMetrics";
 import { MongooseApi } from "../mongoose-api-models/MongooseApi.model";
 import { HttpClient } from "@angular/common/http";
 import { ControlApiService } from "../control-api/control-api.service";
+import { LocalStorageService } from "../local-storage-service/local-storage.service";
 
 
 @Injectable({
@@ -27,7 +28,8 @@ export class MonitoringApiService {
 
   constructor(private prometheusApiService: PrometheusApiService,
     private controlApiService: ControlApiService,
-    private http: HttpClient) {
+    private http: HttpClient,
+    private localStorageService: LocalStorageService) {
     this.setUpService();
   }
 
@@ -229,7 +231,9 @@ export class MonitoringApiService {
 
       const mongooseRunStatus$ = this.getStatusForMongooseRecord(runId);
 
-      let currentRunRecord = new MongooseRunRecord(runId, loadStepId, mongooseRunStatus$, startTime, nodesList, duration, userComment);
+      let entryNode = this.localStorageService.getEntryNodeAddressForRunId(runId);
+
+      let currentRunRecord = new MongooseRunRecord(loadStepId, mongooseRunStatus$, startTime, nodesList, duration, userComment, entryNode);
       runRecords.push(currentRunRecord);
     }
 

--- a/console/src/app/core/services/monitoring-api/monitoring-api.service.ts
+++ b/console/src/app/core/services/monitoring-api/monitoring-api.service.ts
@@ -144,7 +144,7 @@ export class MonitoringApiService {
   }
 
 
-  public getLog(stepId: String, logName: String): Observable<any> {
+  public getLog(mongooseNodeAddress: string, stepId: String, logName: String): Observable<any> {
     let logsEndpoint = MongooseApi.LogsApi.LOGS;
     let targetUrl = "";
     let delimiter = "/";
@@ -154,11 +154,11 @@ export class MonitoringApiService {
       // NOTE: HTTP request on this URL will return error. 
       // The error will be handled and Mongoose's run status would be set to 'unavailable'. 
       // This is done in case Mongoose has been reloaded, but Prometheus still stores its metrics.
-      targetUrl = this.MONGOOSE_HTTP_ADDRESS + logsEndpoint + delimiter + logName;
+      targetUrl = mongooseNodeAddress + logsEndpoint + delimiter + logName;
     } else {
-      targetUrl = this.MONGOOSE_HTTP_ADDRESS + logsEndpoint + delimiter + stepId + delimiter + logName;
+      targetUrl = mongooseNodeAddress + logsEndpoint + delimiter + stepId + delimiter + logName;
     }
-    return this.http.get(targetUrl, { responseType: 'text' }).pipe(share());
+    return this.http.get(`${Constants.Http.HTTP_PREFIX}${targetUrl}`, { responseType: 'text' }).pipe(share());
   }
 
   public getMongooseRunRecords(): Observable<MongooseRunRecord[]> {
@@ -311,8 +311,8 @@ export class MonitoringApiService {
     return requiredfiltredRecords;
   }
 
-  private isLogFileExist(loadStepId: String, logName: String): Observable<any> {
-    return this.getLog(loadStepId, logName).pipe(
+  private isLogFileExist(runEntryNodeAddress: string, loadStepId: String, logName: String): Observable<any> {
+    return this.getLog(runEntryNodeAddress, loadStepId, logName).pipe(
       map(hasConfig => hasConfig = of(true)),
       catchError(hasConfig => hasConfig = of(false))
     );

--- a/console/src/app/core/services/monitoring-api/monitoring-api.service.ts
+++ b/console/src/app/core/services/monitoring-api/monitoring-api.service.ts
@@ -39,8 +39,8 @@ export class MonitoringApiService {
   public getStatusForMongooseRecord(mongooseRunEntryNode: MongooseRunEntryNode): Observable<MongooseRunStatus> {
     // NOTE: As for now, we're checking status for Mongoose run overtall, not just Run ID. 
     return this.controlApiService.getStatusForMongooseRun(mongooseRunEntryNode).pipe(
-      map((mongooseRunStatus: MongooseRunStatus) => { 
-       return mongooseRunStatus;
+      map((mongooseRunStatus: MongooseRunStatus) => {
+        return mongooseRunStatus;
       })
     ).pipe(
       share()
@@ -67,7 +67,7 @@ export class MonitoringApiService {
   }
 
   public getMongooseRunRecordByLoadStepId(loadStepId: String): Observable<MongooseRunRecord> {
-    if (loadStepId == "") { 
+    if (loadStepId == "") {
       throw Error("Load step ID hasn't been saved.");
     }
     return this.getCurrentMongooseRunRecords().pipe(
@@ -231,15 +231,14 @@ export class MonitoringApiService {
       let duration = computedRunData[durationIndex];
 
       let entryNode = undefined;
-      try { 
-       entryNode = this.localStorageService.getEntryNodeAddressForRunId(runId);
+      try {
+        entryNode = this.localStorageService.getEntryNodeAddressForRunId(runId);
       } catch (entryNodeNotFoundError) {
         console.error(`Unable to create entry node instance. Details: ${entryNodeNotFoundError}`);
         const NOT_EXISTING_ADDRESS = "address-not-exist";
         entryNode = new MongooseRunEntryNode(NOT_EXISTING_ADDRESS, runId);
       }
       const mongooseRunStatus$ = this.getStatusForMongooseRecord(entryNode);
-
 
       let currentRunRecord = new MongooseRunRecord(loadStepId, mongooseRunStatus$, startTime, nodesList, duration, userComment, entryNode);
       runRecords.push(currentRunRecord);

--- a/console/src/app/core/services/monitoring-api/monitoring-api.service.ts
+++ b/console/src/app/core/services/monitoring-api/monitoring-api.service.ts
@@ -235,7 +235,7 @@ export class MonitoringApiService {
         entryNode = this.localStorageService.getEntryNodeAddressForRunId(runId);
       } catch (entryNodeNotFoundError) {
         console.error(`Unable to create entry node instance. Details: ${entryNodeNotFoundError}`);
-        const NOT_EXISTING_ADDRESS = "address-not-exist";
+        const NOT_EXISTING_ADDRESS = MongooseRunEntryNode.ADDRESS_NOT_EXIST;
         entryNode = new MongooseRunEntryNode(NOT_EXISTING_ADDRESS, runId);
       }
       const mongooseRunStatus$ = this.getStatusForMongooseRecord(entryNode);

--- a/console/src/app/modules/app-module/app.module.ts
+++ b/console/src/app/modules/app-module/app.module.ts
@@ -19,7 +19,8 @@ import { BrowserModule } from '@angular/platform-browser';
 import { ChartsModule } from 'ng2-charts';
 import { PrometheusApiService } from "src/app/core/services/prometheus-api/prometheus-api.service";
 import { BasicChartComponent } from './components/run-statistics/run-statistics-charts/basic-chart/basic-chart.component';
-
+import { StorageServiceModule } from "ngx-webstorage-service";
+import { LocalStorageService } from "src/app/core/services/local-storage-service/local-storage.service";
 
 @NgModule({
   declarations: [
@@ -28,13 +29,13 @@ import { BasicChartComponent } from './components/run-statistics/run-statistics-
     RunsTableComponent,
     MongooseRunStatusIconComponent,
     RunsTableRootComponent,
-    
+
     RunStatisticsComponent,
     RunStatisticLogsComponent,
     RunStatisticsChartsComponent,
     DateFormatPipe,
     BasicChartComponent
-    
+
   ],
   entryComponents: [
     BasicChartComponent
@@ -47,12 +48,13 @@ import { BasicChartComponent } from './components/run-statistics/run-statistics-
     AppRoutingModule,
     MongooseSetUpModuleModule,
     BrowserAnimationsModule,
-    ChartsModule
-    ],
+    ChartsModule,
+    StorageServiceModule
+  ],
 
   // NOTE: Both Control and Monitoring APIs should be instantiated in module level ...
   // ... since we use it for the set up. 
-  providers: [ControlApiService, MonitoringApiService, DateFormatPipe, PrometheusApiService],
+  providers: [ControlApiService, MonitoringApiService, DateFormatPipe, PrometheusApiService, LocalStorageService],
   bootstrap: [AppComponent],
   exports: [AppComponent],
 })

--- a/console/src/app/modules/app-module/components/run-statistics/run-statistic-logs/run-statistic-logs.component.ts
+++ b/console/src/app/modules/app-module/components/run-statistics/run-statistic-logs/run-statistic-logs.component.ts
@@ -73,7 +73,7 @@ export class RunStatisticLogsComponent implements OnInit {
     let emptyErrorHtmlValue = "";
     this.occuredError = emptyErrorHtmlValue;
 
-    this.monitoringApiService.getLog(this.processingRunRecord.getLoadStepId(), logApiEndpoint).subscribe(
+    this.monitoringApiService.getLog(this.processingRunRecord.getEntryNodeAddress(), this.processingRunRecord.getLoadStepId(), logApiEndpoint).subscribe(
       logs => {
         this.displayingLog = logs;
       },

--- a/console/src/app/modules/app-module/components/run-statistics/run-statistics.component.ts
+++ b/console/src/app/modules/app-module/components/run-statistics/run-statistics.component.ts
@@ -95,7 +95,8 @@ export class RunStatisticsComponent implements OnInit {
 
   public onTerminateBtnClicked(runRecord: MongooseRunRecord) { 
     let terminatingRunId = runRecord.getRunId();
-    this.controlApiService.terminateMongooseRun(terminatingRunId as string).subscribe(
+    let terminatingRunEntryNodeAddress = runRecord.getEntryNodeAddress();
+    this.controlApiService.terminateMongooseRun(terminatingRunEntryNodeAddress, terminatingRunId as string).subscribe(
       (terminationStatusMessage: string) => { 
         alert(terminationStatusMessage);
         window.location.reload();

--- a/console/src/app/modules/mongoose-set-up-module/components/mongoose-set-up/mongoose-set-up.component.ts
+++ b/console/src/app/modules/mongoose-set-up-module/components/mongoose-set-up/mongoose-set-up.component.ts
@@ -81,7 +81,9 @@ export class MongooseSetUpComponent implements OnInit {
   }
 
   public onRunBtnClicked() {
-    this.mongooseRunSubscription = this.mongooseSetUpService.runMongoose().subscribe(
+    // NOTE: Launching Mongoose on its entry node.
+    let mongooseEntryNode = this.mongooseSetUpService.getMongooseEntryNode();
+    this.mongooseRunSubscription = this.mongooseSetUpService.runMongoose(mongooseEntryNode).subscribe(
       mongooseRunId => {
         // NOTE: Updated Metrics will include both run ID and load step ID. In case ...
         // ... it won't be implimented, map them here. If you want to get ...

--- a/console/src/app/modules/mongoose-set-up-module/components/mongoose-set-up/mongoose-set-up.component.ts
+++ b/console/src/app/modules/mongoose-set-up-module/components/mongoose-set-up/mongoose-set-up.component.ts
@@ -41,7 +41,7 @@ export class MongooseSetUpComponent implements OnInit {
     let defaultTabNumber = 0;
     this.openUpTab(defaultTabNumber);
   }
-  
+
   ngOnInit() { }
 
   ngOnDestroy() {
@@ -64,9 +64,9 @@ export class MongooseSetUpComponent implements OnInit {
   public onConfirmClicked() {
     let processingTab = this.getCurrentSetupTab();
     processingTab.isCompleted = this.getSetUpTabComplitionStatus();
-    if (!processingTab.isCompleted) { 
+    if (!processingTab.isCompleted) {
       alert(`Please, select Mongoose run nodes before continuing.`);
-      return; 
+      return;
     }
     let nextTabId = this.processingTabID + 1;
     this.switchTab(nextTabId);
@@ -83,39 +83,39 @@ export class MongooseSetUpComponent implements OnInit {
   public onRunBtnClicked() {
     this.mongooseRunSubscription = this.mongooseSetUpService.runMongoose().subscribe(
       mongooseRunId => {
-      // NOTE: Updated Metrics will include both run ID and load step ID. In case ...
-      // ... it won't be implimented, map them here. If you want to get ...
-      // ... load step id, you can do it via mongoose set up service. 
-      console.log("Launched Mongoose run with run ID: ", mongooseRunId);
-      
-      // NOTE: If run ID has been returned from the server, Mongoose run has started
-      let hasMongooseSuccessfullyStarted = (mongooseRunId != undefined);
-      if (!hasMongooseSuccessfullyStarted) {
-        let misleadingMessage = `Unable to launch Mongoose - run ID hasn't been generated. Details: ${JSON.stringify(mongooseRunId)}`;
-        alert(misleadingMessage);
-      } else {
-        let misleadingMessage = "Mongoose Run has started with ID " + mongooseRunId;
-        alert(misleadingMessage);
-      }
-      
-      this.router.navigate([RoutesList.RUNS]);
-    },
-    error => { 
-      let errorReason = ""; 
-      if (error.status != undefined) { 
-        if (error.status == Constants.HttpStatus.CONFLICT) { 
-          errorReason = "Another Mongoose run has already been launched on port " + this.mongooseSetUpService.getMongooseRunTargetPort() + ".";
+        // NOTE: Updated Metrics will include both run ID and load step ID. In case ...
+        // ... it won't be implimented, map them here. If you want to get ...
+        // ... load step id, you can do it via mongoose set up service. 
+        console.log("Launched Mongoose run with run ID: ", mongooseRunId);
+
+        // NOTE: If run ID has been returned from the server, Mongoose run has started
+        let hasMongooseSuccessfullyStarted = (mongooseRunId != undefined);
+        if (!hasMongooseSuccessfullyStarted) {
+          let misleadingMessage = `Unable to launch Mongoose - run ID hasn't been generated. Details: ${JSON.stringify(mongooseRunId)}`;
+          alert(misleadingMessage);
+        } else {
+          let misleadingMessage = "Mongoose Run has started with ID " + mongooseRunId;
+          alert(misleadingMessage);
         }
-      }
-      let misleadingMessage = `Unable to launch Mongoose. Details: ${JSON.stringify(error)}`;
-      let emptyString = "";
-      if (errorReason != emptyString) { 
-        let phrasesDelimiter = " ";
-        misleadingMessage += phrasesDelimiter + "Reason: " + errorReason;
-      }
-      alert(misleadingMessage);
-      console.error(misleadingMessage + error);
-    });
+
+        this.router.navigate([RoutesList.RUNS]);
+      },
+      error => {
+        let errorReason = "";
+        if (error.status != undefined) {
+          if (error.status == Constants.HttpStatus.CONFLICT) {
+            errorReason = "Another Mongoose run has already been launched on port " + this.mongooseSetUpService.getMongooseRunTargetPort() + ".";
+          }
+        }
+        let misleadingMessage = `Unable to launch Mongoose. Details: ${JSON.stringify(error)}`;
+        let emptyString = "";
+        if (errorReason != emptyString) {
+          let phrasesDelimiter = " ";
+          misleadingMessage += phrasesDelimiter + "Reason: " + errorReason;
+        }
+        alert(misleadingMessage);
+        console.error(misleadingMessage + error);
+      });
   }
 
   public onRouterComponentActivated($event) { }
@@ -161,9 +161,9 @@ export class MongooseSetUpComponent implements OnInit {
     this.openUpTab(nextTabId);
   }
 
-  private getSetUpTabComplitionStatus(): boolean { 
+  private getSetUpTabComplitionStatus(): boolean {
     // NOTE: Allowing switching set up tab only if target run nodes were selected 
-    let hasMongooseRunNodesSelected = (this.mongooseSetUpService.getTargetRunNodes().length > 0); 
+    let hasMongooseRunNodesSelected = (this.mongooseSetUpService.getSelectedMongooseRunNodes().length > 0);
     return hasMongooseRunNodesSelected;
   }
 }

--- a/console/src/app/modules/mongoose-set-up-module/components/mongoose-set-up/set-up-steps/configuration-set-up/configuration-editing/configuration-editing.component.ts
+++ b/console/src/app/modules/mongoose-set-up-module/components/mongoose-set-up/set-up-steps/configuration-set-up/configuration-editing/configuration-editing.component.ts
@@ -3,6 +3,7 @@ import { JsonEditorComponent, JsonEditorOptions } from 'ang-jsoneditor';
 import { Constants } from 'src/app/common/constants';
 import { Subscription } from 'rxjs';
 import { MongooseSetUpService } from 'src/app/core/services/mongoose-set-up-service/mongoose-set-up.service';
+import { MongooseRunNode } from 'src/app/core/models/mongoose-run-node.model';
 
 
 @Component({
@@ -52,8 +53,9 @@ export class ConfigurationEditingComponent implements OnInit {
   // MARK: - Private 
 
   private configureJsonEditor() {
+    let mongooseEntryNode: MongooseRunNode = this.mongooseSetUpService.getMongooseEntryNode(); 
     this.monitoringApiSubscriptions.add(
-      this.mongooseSetUpService.getMongooseConfigurationForSetUp().subscribe(
+      this.mongooseSetUpService.getMongooseConfigurationForSetUp(mongooseEntryNode).subscribe(
         configuration => {
           this.initialJsonEditorConfiguration = configuration;
         },

--- a/console/src/app/modules/mongoose-set-up-module/components/mongoose-set-up/set-up-steps/configuration-set-up/control-editing-root/control-editing-root.component.ts
+++ b/console/src/app/modules/mongoose-set-up-module/components/mongoose-set-up/set-up-steps/configuration-set-up/control-editing-root/control-editing-root.component.ts
@@ -10,5 +10,4 @@ export class ConfigurationEditingRootComponent implements OnInit {
   constructor() { }
 
   ngOnInit() {}
-å
 }

--- a/console/src/app/modules/mongoose-set-up-module/components/mongoose-set-up/set-up-steps/nodes/nodes.component.html
+++ b/console/src/app/modules/mongoose-set-up-module/components/mongoose-set-up/set-up-steps/nodes/nodes.component.html
@@ -16,9 +16,6 @@
         <th scope="row">
           <!-- Default unchecked -->
            <div class="custom-control custom-checkbox">
-              <!-- <input type="checkbox"  
-              (ngModelChange)="onRunNodeSelect(savedNode)"
-              (click)="onRunNodeSelect(savedNode)"> -->
             <input type="checkbox" class="custom-control-input" id="{{ savedNode.getResourceLocation() }}" (click)="onRunNodeSelect(savedNode)">
             <label class="custom-control-label" for="{{ savedNode.getResourceLocation() }}" ></label>
           </div>

--- a/console/src/app/modules/mongoose-set-up-module/components/mongoose-set-up/set-up-steps/nodes/nodes.component.ts
+++ b/console/src/app/modules/mongoose-set-up-module/components/mongoose-set-up/set-up-steps/nodes/nodes.component.ts
@@ -54,7 +54,9 @@ export class NodesComponent implements OnInit {
   }
 
   public onRunNodeSelect(selectedNode: MongooseRunNode) {
-    this.mongooseSetUpService.addNode(selectedNode);
+    let hasNodeBeenSelected: boolean = this.mongooseSetUpService.isNodeExist(selectedNode);
+    // NOTE: Add noode if check mark has been set, remove if unset
+    hasNodeBeenSelected ? this.mongooseSetUpService.removeNode(selectedNode) : this.mongooseSetUpService.addNode(selectedNode);
   }
 
   private isipValid(entredIpAddress: string) {

--- a/console/src/app/modules/mongoose-set-up-module/mongoose-set-up-module.module.ts
+++ b/console/src/app/modules/mongoose-set-up-module/mongoose-set-up-module.module.ts
@@ -13,6 +13,7 @@ import { SetUpFooterComponent } from "./components/mongoose-set-up/set-up-footer
 import { ControlApiService } from "src/app/core/services/control-api/control-api.service";
 import { MonitoringApiService } from "src/app/core/services/monitoring-api/monitoring-api.service";
 import { DateFormatPipe } from "src/app/common/date-format-pipe";
+import { LocalStorageService } from "src/app/core/services/local-storage-service/local-storage.service";
 
 
 @NgModule({
@@ -36,7 +37,8 @@ import { DateFormatPipe } from "src/app/common/date-format-pipe";
   providers: [
     ControlApiService,
     MonitoringApiService,
-    DateFormatPipe
+    DateFormatPipe,
+    LocalStorageService
   ],
   bootstrap: [
     MongooseSetUpComponent


### PR DESCRIPTION
On "Nodes" screen, user could select multiple nodes.
**Now**: we're assuming Mongoose running on localhost:9999 (or any other address listen within .env file)
**Then**: we should select first node from the added nodes list as entry node. Other nodes should be added into configuration in order to run Mongoose in distributed mode.

Related JIRA's task: https://mongoose-issues.atlassian.net/projects/GUI/issues/GUI-128?filter=allopenissues